### PR TITLE
allow empty query parameter values

### DIFF
--- a/http/src/test/scala/spinoco/protocol/http/UriSpec.scala
+++ b/http/src/test/scala/spinoco/protocol/http/UriSpec.scala
@@ -36,6 +36,27 @@ object UriSpec extends Properties("Uri") {
         , Uri(HttpScheme.HTTP, HostPort("127.0.0.1", Some(8080)), Uri.Path.Root, Uri.Query.empty)
         , "http://127.0.0.1:8080/"
       )
+      , ("http://www.spinoco.com/?q=1&w=2"
+        , Uri(HttpScheme.HTTP, HostPort("www.spinoco.com", None), Uri.Path.Root, Uri.Query(List("q" -> "1", "w" -> "2")))
+        , "http://www.spinoco.com/?q=1&w=2"
+      )
+      , ("http://www.spinoco.com/?q=1&q=2"
+        , Uri(HttpScheme.HTTP, HostPort("www.spinoco.com", None), Uri.Path.Root, Uri.Query(List("q" -> "1", "q" -> "2")))
+        , "http://www.spinoco.com/?q=1&q=2"
+      )
+      , ("http://www.spinoco.com/?q=&w=2"
+        , Uri(HttpScheme.HTTP, HostPort("www.spinoco.com", None), Uri.Path.Root, Uri.Query(List("q" -> "", "w" -> "2")))
+        , "http://www.spinoco.com/?q&w=2"
+      )
+      , ("http://www.spinoco.com/?q&w=2"
+        , Uri(HttpScheme.HTTP, HostPort("www.spinoco.com", None), Uri.Path.Root, Uri.Query(List("q" -> "", "w" -> "2")))
+        , "http://www.spinoco.com/?q&w=2"
+      )
+      , ("http://www.spinoco.com/?q=1&w"
+        , Uri(HttpScheme.HTTP, HostPort("www.spinoco.com", None), Uri.Path.Root, Uri.Query(List("q" -> "1", "w" -> "")))
+        , "http://www.spinoco.com/?q=1&w"
+      )
+
     )
 
     examples.foldLeft(proved) {


### PR DESCRIPTION
Hi @pchlupacek 

this is my attempt at solving the empty query parameter problem. These are my first steps with scodec library, so I'm not sure if that makes sense. I added some happy-path tests. Please let me know what I can improve here. Thanks!

It's interesting to me that these two cases `a::b::Nil` and `a::Nil` luckily exactly map to the concrete use-case: the first yields when key and value are given, the second if only the key is given. It fails on input like `=z`.