### PR TITLE
Allow uris with empty paths

### DIFF
--- a/http/src/test/scala/spinoco/protocol/http/UriSpec.scala
+++ b/http/src/test/scala/spinoco/protocol/http/UriSpec.scala
@@ -56,7 +56,22 @@ object UriSpec extends Properties("Uri") {
         , Uri(HttpScheme.HTTP, HostPort("www.spinoco.com", None), Uri.Path.Root, Uri.Query(List("q" -> "1", "w" -> "")))
         , "http://www.spinoco.com/?q=1&w"
       )
-
+      , ("http://www.spinoco.com?q=1"
+        , Uri(HttpScheme.HTTP, HostPort("www.spinoco.com", None), Uri.Path.Empty, Uri.Query(List("q" -> "1")))
+        , "http://www.spinoco.com?q=1"
+      )
+      , ("http://www.spinoco.com"
+        , Uri(HttpScheme.HTTP, HostPort("www.spinoco.com", None), Uri.Path.Empty, Uri.Query.empty)
+        , "http://www.spinoco.com"
+      )
+      , ("http://www.spinoco.com?"
+        , Uri(HttpScheme.HTTP, HostPort("www.spinoco.com", None), Uri.Path.Empty, Uri.Query.empty)
+        , "http://www.spinoco.com"
+      )
+      , ("http://www.spinoco.com/?"
+        , Uri(HttpScheme.HTTP, HostPort("www.spinoco.com", None), Uri.Path.Root, Uri.Query.empty)
+        , "http://www.spinoco.com/"
+      )
     )
 
     examples.foldLeft(proved) {


### PR DESCRIPTION
Hello again,

this is the second part to issue #5 that allows to parse uris without a path part. For example: `http://www.spinoco.com` or `http://www.spinoco.com?q=1` (in contrast to `http://www.spinoco.com/` and `http://www.spinoco.com/?q=1`). The codec for `Path` already supports the empty path, so the change was only to allow an empty path following `HostPort` part of the uri (which can now end in a `/` or a `?`). 

I added a `Path.Empty` value that has no segments and no slashes. 

I hope this is ok, please let me know what I can improve. Thank you!