### PR TITLE
Fix payload length parsing for values from 2^15 to 2^16-1

### DIFF
--- a/websocket/src/main/scala/spinoco/protocol/websocket/codec/WebSocketFrameCodec.scala
+++ b/websocket/src/main/scala/spinoco/protocol/websocket/codec/WebSocketFrameCodec.scala
@@ -62,11 +62,7 @@ object WebSocketFrameCodec {
 
       ("Length Header" | uint(7)).flatZip {
         case sz if sz <= 125 => constant(ByteVector.empty).xmap(_ => sz, (_: Int) => ())
-        case sz if sz == 126 =>
-          long(16).exmap[Int] (
-            lsz => Attempt.successful(lsz.toInt)
-            , i => Attempt.successful(i.toLong)
-          )
+        case sz if sz == 126 => uint(16)
         case sz =>
           long(64).exmap[Int] (
             lsz => if (lsz <= Int.MaxValue)  Attempt.successful(lsz.toInt) else Attempt.failure(Err(s"Max supported size is ${Int.MaxValue}, got $lsz"))

--- a/websocket/src/main/scala/spinoco/protocol/websocket/codec/WebSocketFrameCodec.scala
+++ b/websocket/src/main/scala/spinoco/protocol/websocket/codec/WebSocketFrameCodec.scala
@@ -55,26 +55,31 @@ object WebSocketFrameCodec {
 
 
 
-    // this supports only size of Long.MaxValue.
-    // In theory we may have size of unsigned long, which aren't supported by this implementation
-    // anyhow the max value of the payload supported is Int.MaxValue, that is about 2G
+    // The maximum payload length is Long.MaxValue due to the spec requiring that the most
+    // significant bit must be 0. This implementation only supports a max payload length of
+    // Int.MaxValue, that is about 2G.
     def payloadLength:Codec[Int] = {
 
       ("Length Header" | uint(7)).flatZip {
         case sz if sz <= 125 => constant(ByteVector.empty).xmap(_ => sz, (_: Int) => ())
         case sz if sz == 126 => uint(16)
-        case sz =>
-          long(64).exmap[Int] (
-            lsz => if (lsz <= Int.MaxValue)  Attempt.successful(lsz.toInt) else Attempt.failure(Err(s"Max supported size is ${Int.MaxValue}, got $lsz"))
+        case _ =>
+          long(64).exmap[Int](
+            {
+              case lsz if lsz < 0 => Attempt.failure(Err(s"The most significant bit must be 0"))
+              case lsz if lsz <= Int.MaxValue => Attempt.successful(lsz.toInt)
+              case lsz => Attempt.failure(Err(s"Max supported size is ${Int.MaxValue}, got $lsz"))
+            }
             , i => Attempt.successful(i.toLong)
           )
 
       }.exmap(
         { case (_, sz) => Attempt.successful(sz)  }
         , {
+          case sz if sz < 0 => Attempt.failure(Err("Negative payload sizes are not allowed"))
           case sz if sz <= 125 => Attempt.successful((sz, sz))
-          case sz if sz > 125 && sz <= 65535 => Attempt.successful((126, sz))
-          case sz if sz < Int.MaxValue  => Attempt.successful((127, sz))
+          case sz if sz <= 65535 => Attempt.successful((126, sz))
+          case sz if sz <= Int.MaxValue => Attempt.successful((127, sz))
           case _ => Attempt.failure(Err("Only payloads size of <= Int.MaxValue are supported"))
         }
       )


### PR DESCRIPTION
From RFC 6455:
"If 126, the following 2 bytes interpreted as a 16-bit unsigned integer are the payload length."

As such the codec has been changed from a 16-bit signed long to a 16-bit unsigned integer.

Update the 64-bit payload length parsing to fail if the resulting long value is a negative number. A negative number would mean that the most significant bit is not 0 which is required by RFC 6455.

Additionally update the encoder to fail if a negative integer is provided.