### PR TITLE
RFC3986 URI path segment encoding

### DIFF
--- a/http/src/main/scala/spinoco/protocol/http/codec/RFC3986.scala
+++ b/http/src/main/scala/spinoco/protocol/http/codec/RFC3986.scala
@@ -1,0 +1,51 @@
+package spinoco.protocol.http.codec
+
+import java.nio.charset.StandardCharsets
+
+import scala.collection.immutable.BitSet
+
+/**
+  * https://tools.ietf.org/html/rfc3986
+  */
+object RFC3986 {
+
+  val genDelims = BitSet(':', '/', '?', '#', '[', ']', '@')
+
+  val subDelims = BitSet('!', '$', '&', ''', '(', ')' , '*', '+', ',', ';', '=')
+
+  val reserved  = genDelims ++ subDelims
+
+  val alpha = BitSet((('a' to 'z') ++ ('A' to 'Z')).map(_.toInt): _*)
+
+  val digit = BitSet(('0' to '9').map(_.toInt): _*)
+
+  val unreserved = alpha ++ digit ++ BitSet('-', '.', '_', '~')
+
+  val pchar = unreserved ++ subDelims ++ BitSet(':', '@')
+
+
+  // https://tools.ietf.org/html/rfc3986#section-3.1
+  val scheme = alpha ++ digit ++ BitSet('+', '-', '.')
+
+  // https://tools.ietf.org/html/rfc3986#section-3.3
+  val pathSegment = pchar
+
+
+  def encode(str: String, allowedChars: BitSet): String = {
+    // add a buffer to hopefully account for all chars that need to be escaped
+    val sb = new StringBuilder(str.length * 12 / 10)
+    str.foreach { c =>
+      if (allowedChars.contains(c)) sb.append(c)
+      else {
+        // https://tools.ietf.org/html/rfc3986#section-2.5
+        c.toString.getBytes(StandardCharsets.UTF_8).foreach { b =>
+          sb.append("%" + "%02X".format(b))
+        }
+      }
+    }
+    sb.mkString
+  }
+
+  def encodePathSegment(segment: String): String = encode(segment, pathSegment)
+
+}

--- a/http/src/test/scala/spinoco/protocol/http/UriSpec.scala
+++ b/http/src/test/scala/spinoco/protocol/http/UriSpec.scala
@@ -73,6 +73,10 @@ object UriSpec extends Properties("Uri") {
         , Uri(HttpScheme.HTTP, HostPort("www.spinoco.com", None), Uri.Path.Root, Uri.Query.empty)
         , "http://www.spinoco.com/"
       )
+      , ("http://www.spinoco.com/aA0-._~/!$&'()*+,;=/:@/%5B%5D%2F%7B%7D%C3%A9"
+        , Uri(HttpScheme.HTTP, HostPort("www.spinoco.com", None), Uri.Path.Root / "aA0-._~" / "!$&'()*+,;=" / ":@" / "[]/{}é", Uri.Query.empty)
+        , "http://www.spinoco.com/aA0-._~/!$&'()*+,;=/:@/%5B%5D%2F%7B%7D%C3%A9"
+      )
       , ("http://x.com/123?a=1&b=2;c=3"
         , Uri(HttpScheme.HTTP, HostPort("x.com", None), Uri.Path.Root / "123", Uri.Query("a", "1") :+ (QueryParameter.single("b", "2") :+ ("c", "3")))
         , "http://x.com/123?a=1&b=2;c=3"


### PR DESCRIPTION
Use an RFC3986 compliant encoder instead of URLEncoder.encode() when
encoding URI path segments.