### PR TITLE
We can now read http responses that are missing status code description.

### DIFF
--- a/http/src/main/scala/spinoco/protocol/http/codec/HttpResponseHeaderCodec.scala
+++ b/http/src/main/scala/spinoco/protocol/http/codec/HttpResponseHeaderCodec.scala
@@ -29,7 +29,13 @@ object HttpResponseHeaderCodec {
 
     parametrizedN(crlf, crlf, "Response" | headerLineCodec, "Headers" | headerCodec).xmap[HttpResponseHeader] (
       { case (version :: status :: phrase :: HNil, headers) => HttpResponseHeader(status, phrase, headers, version) }
-      , h => ( h.version :: h.status :: h.reason :: HNil, h.headers)
+      , h => {
+        val description =
+          if (h.reason.isEmpty) h.status.description
+          else h.reason
+
+        ( h.version :: h.status :: description :: HNil, h.headers)
+      }
     )
   }
 

--- a/http/src/test/scala/spinoco/protocol/http/codec/HttpResponseHeaderCodecSpec.scala
+++ b/http/src/test/scala/spinoco/protocol/http/codec/HttpResponseHeaderCodecSpec.scala
@@ -48,7 +48,7 @@ object HttpResponseHeaderCodecSpec extends Properties("HttpResponseHeaderCodec")
     HttpResponseHeaderCodec.defaultCodec.encode(
       HttpResponseHeader(
         status =  HttpStatusCode.Ok
-        , reason = "OK"
+        , reason = "OK localised"
         , headers = List(
           Date(ZonedDateTime.parse("2009-07-27T12:28:53+00:00").toLocalDateTime)
           , Server(ServerProduct(List(ProductDescription("Apache",Some("2.2.14")))))
@@ -61,7 +61,7 @@ object HttpResponseHeaderCodecSpec extends Properties("HttpResponseHeaderCodec")
       )
     ).map(_.decodeAscii) ?= Attempt.successful(Right(
       Seq(
-        "HTTP/1.1 200 OK"
+        "HTTP/1.1 200 OK localised"
         , "Date: Mon, 27 Jul 2009 12:28:53 GMT"
         , "Server: Apache/2.2.14"
         , "Last-Modified: Wed, 22 Jul 2009 19:15:56 GMT"
@@ -119,7 +119,7 @@ object HttpResponseHeaderCodecSpec extends Properties("HttpResponseHeaderCodec")
       )
     ).map(_.decodeAscii) ?= Attempt.successful(Right(
       Seq(
-        "HTTP/1.1 200"
+        "HTTP/1.1 200 OK"
         , "Date: Mon, 27 Jul 2009 12:28:53 GMT"
         , "Server: Apache/2.2.14"
         , "Last-Modified: Wed, 22 Jul 2009 19:15:56 GMT"

--- a/http/src/test/scala/spinoco/protocol/http/codec/HttpResponseHeaderCodecSpec.scala
+++ b/http/src/test/scala/spinoco/protocol/http/codec/HttpResponseHeaderCodecSpec.scala
@@ -73,4 +73,62 @@ object HttpResponseHeaderCodecSpec extends Properties("HttpResponseHeaderCodec")
 
   }
 
+  property("Response.decode.no-reason") = secure {
+    HttpResponseHeaderCodec.defaultCodec.decode(BitVector(
+      Seq(
+        "HTTP/1.1 200"
+        , "Date: Mon, 27 Jul 2009 12:28:53 GMT"
+        , "Server: Apache/2.2.14"
+        , "Last-Modified: Wed, 22 Jul 2009 19:15:56 GMT"
+        , "Content-Length: 88"
+        , "Content-Type: text/html"
+        , "Connection: Closed"
+      ).mkString("\r\n").getBytes
+    )) ?= Attempt.successful(DecodeResult(
+      HttpResponseHeader(
+        status =  HttpStatusCode.Ok
+        , reason = "OK"
+        , headers = List(
+          Date(ZonedDateTime.parse("2009-07-27T12:28:53+00:00").toLocalDateTime)
+          , Server(ServerProduct(List(ProductDescription("Apache",Some("2.2.14")))))
+          , `Last-Modified`(ZonedDateTime.parse("2009-07-22T19:15:56+00:00").toLocalDateTime)
+          , `Content-Length`(88)
+          , `Content-Type`(ContentType.TextContent(MediaType.`text/html`, None))
+          , Connection(List("Closed"))
+        )
+        , version = HttpVersion.V1_1
+      )
+      , BitVector.empty))
+  }
+
+  property("Response.encode.no-reason") = secure {
+
+    HttpResponseHeaderCodec.defaultCodec.encode(
+      HttpResponseHeader(
+        status =  HttpStatusCode.Ok
+        , reason = ""
+        , headers = List(
+          Date(ZonedDateTime.parse("2009-07-27T12:28:53+00:00").toLocalDateTime)
+          , Server(ServerProduct(List(ProductDescription("Apache",Some("2.2.14")))))
+          , `Last-Modified`(ZonedDateTime.parse("2009-07-22T19:15:56+00:00").toLocalDateTime)
+          , `Content-Length`(88)
+          , `Content-Type`(ContentType.TextContent(MediaType.`text/html`, None))
+          , Connection(List("Closed"))
+        )
+        , version = HttpVersion.V1_1
+      )
+    ).map(_.decodeAscii) ?= Attempt.successful(Right(
+      Seq(
+        "HTTP/1.1 200"
+        , "Date: Mon, 27 Jul 2009 12:28:53 GMT"
+        , "Server: Apache/2.2.14"
+        , "Last-Modified: Wed, 22 Jul 2009 19:15:56 GMT"
+        , "Content-Length: 88"
+        , "Content-Type: text/html"
+        , "Connection: Closed"
+      ).mkString("\r\n")
+    ))
+
+  }
+
 }


### PR DESCRIPTION
This fixes #14. 