### PR TITLE
add text/event-stream to allMediaTypes

### DIFF
--- a/mime/src/main/scala/spinoco/protocol/mime/MediaType.scala
+++ b/mime/src/main/scala/spinoco/protocol/mime/MediaType.scala
@@ -348,6 +348,7 @@ object MediaType {
     , `text/calendar`
     , `text/css`
     , `text/csv`
+    , `text/event-stream`
     , `text/html`
     , `text/mcf`
     , `text/plain`


### PR DESCRIPTION
cannot make SSE connection. After a (very very) quick search I think this could be part of the problem, as `allMediaTypes` is used for parsing the response headers