### PR TITLE
Support Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language : scala
 
 scala:
   - 2.11.12
-  - 2.12.8
+  - 2.12.9
   - 2.13.0
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language : scala
 
 scala:
   - 2.11.12
-  - 2.12.1
+  - 2.12.8
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language : scala
 
 scala:
   - 2.11.12
-  - 2.12.9
+  - 2.12.10
   - 2.13.0
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language : scala
 
 scala:
-  - 2.11.8
+  - 2.11.12
   - 2.12.1
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ cache:
   - $HOME/.sbt
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
-  - sbt "project allProtocols" "++$TRAVIS_SCALA_VERSION test"
+  - sbt -Dfile.encoding=UTF8 "project allProtocols" "++$TRAVIS_SCALA_VERSION test"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language : scala
 scala:
   - 2.11.12
   - 2.12.8
+  - 2.13.0
 
 cache:
   directories:
@@ -14,6 +15,6 @@ jdk:
   - oraclejdk8
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 "project allProtocols" test
+  - sbt "project allProtocols" "++$TRAVIS_SCALA_VERSION test"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language : scala
 scala:
   - 2.11.12
   - 2.12.10
-  - 2.13.0
+  - 2.13.1
 
 cache:
   directories:

--- a/asn1/src/main/scala/spinoco/protocol/asn/ber/package.scala
+++ b/asn1/src/main/scala/spinoco/protocol/asn/ber/package.scala
@@ -1,4 +1,5 @@
-package spinoco.protocol.asn
+package spinoco.protocol
+package asn
 
 import scodec.bits.{BitVector, ByteVector}
 import scodec.codecs.DiscriminatorCodec
@@ -23,11 +24,11 @@ package object ber {
           Attempt.failure(Err.insufficientBits(8, bits.size))
         } else {
           Attempt.fromEither(
-            bits.acquire(2).right.flatMap{classTagBits =>
-            Try(BerClass(classTagBits.toInt(false))).toOption.toRight("Could not get class tag from: " + classTagBits).right.flatMap{ classTag =>
+            bits.acquire(2).flatMap{classTagBits =>
+            Try(BerClass(classTagBits.toInt(false))).toOption.toRight("Could not get class tag from: " + classTagBits).flatMap{ classTag =>
               val constructed = bits.get(2)
               val remaining = bits.drop(3)
-              remaining.acquire(5).right.flatMap { numberTagBits =>
+              remaining.acquire(5).flatMap { numberTagBits =>
                 val numberTag = numberTagBits.toInt(false)
                 if (numberTag >= 31) Left("Tag number can only be 0 - 30, the extended identifier octets are not supported")
                 else Right(DecodeResult(Identifier(classTag, constructed, numberTag), remaining.drop(5)))

--- a/asn1/src/test/scala/spinoco/protocol/asn/ber/BerSpec.scala
+++ b/asn1/src/test/scala/spinoco/protocol/asn/ber/BerSpec.scala
@@ -19,16 +19,16 @@ object BerSpec extends Properties("BER"){
   }
 
   property("length.less.127") = protect {
-    verify(Option(120l), BitVector.fromInt(0x78, 8))(length)
+    verify(Option(120L), BitVector.fromInt(0x78, 8))(length)
   }
 
   property("length.128") = protect {
-    verify(Option(128l), BitVector.fromInt(0x8180, 16))(length)
+    verify(Option(128L), BitVector.fromInt(0x8180, 16))(length)
   }
 
   property("length.3383") = protect {
     // Tests proper encoding of "D37" <- partial octet
-    verify(Option(3383l), BitVector.fromInt(0x820D37 , 24))(length)
+    verify(Option(3383L), BitVector.fromInt(0x820D37 , 24))(length)
   }
 
   property("length.long-max") = protect {

--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,8 @@ lazy val contributors = Seq(
 
 lazy val commonSettings = Seq(
    organization := "com.spinoco",
-   scalaVersion := "2.12.8",
-   crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
+   scalaVersion := "2.12.9",
+   crossScalaVersions := Seq("2.11.12", "2.12.9", "2.13.0"),
    scalacOptions ++= Seq(
     "-feature",
     "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val contributors = Seq(
 
 val Scala211 = "2.11.12"
 val Scala212 = "2.12.10"
-val Scala213 = "2.13.0"
+val Scala213 = "2.13.1"
 
 lazy val commonSettings = Seq(
    organization := "com.spinoco",

--- a/build.sbt
+++ b/build.sbt
@@ -29,10 +29,11 @@ lazy val commonSettings = Seq(
    scalacOptions in (Compile, console) ~= {_.filterNot("-Ywarn-unused-import" == _)},
    scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
    libraryDependencies ++= Seq(
-     "org.scodec" %% "scodec-bits" % "1.1.5"
-     , "org.scodec" %% "scodec-core" % "1.10.3"
-     , "org.scalatest" %% "scalatest" % "3.0.0" % Test
-     , "org.scalacheck" %% "scalacheck" % "1.13.4" % Test
+     "org.scodec" %% "scodec-bits" % "1.1.12"
+     , "org.scodec" %% "scodec-core" % "1.11.4"
+     , "org.scalatest" %% "scalatest" % "3.1.0-SNAP13" % Test
+     , "org.scalatestplus" %% "scalatestplus-scalacheck" % "1.0.0-SNAP8" % Test
+     , "org.scalacheck" %% "scalacheck" % "1.14.0" % Test
    ),
    scmInfo := Some(ScmInfo(url("https://github.com/Spinoco/protocol"), "git@github.com:Spinoco/protocol.git")),
    homepage := None,
@@ -188,7 +189,7 @@ lazy val kafka =
   .settings(
     name := "protocol-kafka"
     , libraryDependencies ++= Seq(
-      "org.xerial.snappy" % "snappy-java" % "1.1.2.1"  // for supporting a Snappy compression of message sets
+      "org.xerial.snappy" % "snappy-java" % "1.1.7.3"  // for supporting a Snappy compression of message sets
       , "org.apache.kafka" %% "kafka" % "0.10.2.0" % Test
     )
   ).dependsOn(

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val contributors = Seq(
 lazy val commonSettings = Seq(
    organization := "com.spinoco",
    scalaVersion := "2.12.1",
-  crossScalaVersions := Seq("2.11.8", "2.12.1"),
+   crossScalaVersions := Seq("2.11.12", "2.12.1"),
    scalacOptions ++= Seq(
     "-feature",
     "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -27,12 +27,12 @@ lazy val commonSettings = Seq(
     "-Ywarn-unused-import"
    ),
    scalacOptions in (Compile, console) ~= {_.filterNot("-Ywarn-unused-import" == _)},
-   scalacOptions in (Test, console) <<= (scalacOptions in (Compile, console)),
+   scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
    libraryDependencies ++= Seq(
      "org.scodec" %% "scodec-bits" % "1.1.5"
      , "org.scodec" %% "scodec-core" % "1.10.3"
-     , "org.scalatest" %% "scalatest" % "3.0.0" % "test"
-     , "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
+     , "org.scalatest" %% "scalatest" % "3.0.0" % Test
+     , "org.scalacheck" %% "scalacheck" % "1.13.4" % Test
    ),
    scmInfo := Some(ScmInfo(url("https://github.com/Spinoco/protocol"), "git@github.com:Spinoco/protocol.git")),
    homepage := None,
@@ -102,9 +102,9 @@ lazy val releaseSettings = Seq(
 )
 
 lazy val noPublish = Seq(
-  publish := (),
-  publishLocal := (),
-  publishSigned := (),
+  publish := {},
+  publishLocal := {},
+  publishSigned := {},
   publishArtifact := false
 )
 
@@ -189,7 +189,7 @@ lazy val kafka =
     name := "protocol-kafka"
     , libraryDependencies ++= Seq(
       "org.xerial.snappy" % "snappy-java" % "1.1.2.1"  // for supporting a Snappy compression of message sets
-      , "org.apache.kafka" %% "kafka" % "0.10.2.0" % "test"
+      , "org.apache.kafka" %% "kafka" % "0.10.2.0" % Test
     )
   ).dependsOn(
     common

--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,8 @@ lazy val contributors = Seq(
 
 lazy val commonSettings = Seq(
    organization := "com.spinoco",
-   scalaVersion := "2.12.1",
-   crossScalaVersions := Seq("2.11.12", "2.12.1"),
+   scalaVersion := "2.12.8",
+   crossScalaVersions := Seq("2.11.12", "2.12.8"),
    scalacOptions ++= Seq(
     "-feature",
     "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val contributors = Seq(
 lazy val commonSettings = Seq(
    organization := "com.spinoco",
    scalaVersion := "2.12.8",
-   crossScalaVersions := Seq("2.11.12", "2.12.8"),
+   crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
    scalacOptions ++= Seq(
     "-feature",
     "-deprecation",
@@ -21,11 +21,12 @@ lazy val commonSettings = Seq(
     "-language:higherKinds",
     "-language:existentials",
     "-language:postfixOps",
-    "-Xfatal-warnings",
-    "-Yno-adapted-args",
+//    "-Xfatal-warnings",
     "-Ywarn-value-discard",
-    "-Ywarn-unused-import"
-   ),
+   ) ++ (if (!scalaVersion.value.startsWith("2.13"))
+          Seq("-Yno-adapted-args", "-Ywarn-unused-import")
+        else
+          Seq.empty),
    scalacOptions in (Compile, console) ~= {_.filterNot("-Ywarn-unused-import" == _)},
    scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
    libraryDependencies ++= Seq(
@@ -149,7 +150,6 @@ lazy val stun =
   )
   .dependsOn(common)
 
-
 lazy val webSocket =
   project.in(file("websocket"))
   .settings(commonSettings)
@@ -165,9 +165,6 @@ lazy val http =
     name := "protocol-http"
   )
   .dependsOn(common, mime)
-
-
-
 
 lazy val sdp =
   project.in(file("sdp"))
@@ -187,6 +184,7 @@ lazy val kafka =
   project.in(file("kafka"))
   .settings(commonSettings)
   .settings(
+    crossScalaVersions := Seq("2.11.12", "2.12.8"),
     name := "protocol-kafka"
     , libraryDependencies ++= Seq(
       "org.xerial.snappy" % "snappy-java" % "1.1.7.3"  // for supporting a Snappy compression of message sets
@@ -217,6 +215,9 @@ lazy val allProtocols =
   project.in(file("."))
  .settings(commonSettings)
  .settings(noPublish)
+ .settings(
+   crossScalaVersions := Seq("2.11.12", "2.12.8")
+ )
  .aggregate(
    common
    , mime

--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,9 @@ lazy val commonSettings = Seq(
     "-language:higherKinds",
     "-language:existentials",
     "-language:postfixOps",
-//    "-Xfatal-warnings",
     "-Ywarn-value-discard",
    ) ++ (if (!scalaVersion.value.startsWith("2.13"))
-          Seq("-Yno-adapted-args", "-Ywarn-unused-import")
+          Seq("-Xfatal-warnings", "-Yno-adapted-args", "-Ywarn-unused-import")
         else
           Seq.empty),
    scalacOptions in (Compile, console) ~= {_.filterNot("-Ywarn-unused-import" == _)},

--- a/common/src/main/scala-2.11/spinoco/protocol/package.scala
+++ b/common/src/main/scala-2.11/spinoco/protocol/package.scala
@@ -1,0 +1,13 @@
+package spinoco
+
+package object protocol {
+
+  implicit class RightBiasedEither[A, B](val either: Either[A, B]) extends AnyVal {
+    def map[B1](f: B => B1): Either[A, B1] = either.right.map(f)
+    def flatMap[A1 >: A, B1](f: B => Either[A1, B1]): Either[A1, B1] = either.right.flatMap(f)
+    def toOption: Option[B] = either match {
+      case Right(b) => Some(b)
+      case _        => None
+    }
+  }
+}

--- a/common/src/main/scala-2.12/spinoco/protocol/package.scala
+++ b/common/src/main/scala-2.12/spinoco/protocol/package.scala
@@ -1,0 +1,3 @@
+package spinoco
+
+package object protocol {}

--- a/common/src/main/scala-2.13+/spinoco/protocol/package.scala
+++ b/common/src/main/scala-2.13+/spinoco/protocol/package.scala
@@ -1,0 +1,3 @@
+package spinoco
+
+package object protocol {}

--- a/common/src/main/scala/spinoco/protocol/common/codec.scala
+++ b/common/src/main/scala/spinoco/protocol/common/codec.scala
@@ -15,8 +15,6 @@ import scala.concurrent.duration.{FiniteDuration, TimeUnit}
 import util.attemptFromEither
 import util.attempt
 
-import scala.collection.GenTraversable
-
 object codec {
 
 
@@ -653,7 +651,7 @@ object codec {
 
 
   /** will encode a collection of `A` with min size of at least `sz`  **/
-  def minItems[A, F[_] <: GenTraversable[_]](sz:Int)(codec: Codec[F[A]]): Codec[F[A]] = {
+  def minItems[A, F[_] <: Iterable[_]](sz:Int)(codec: Codec[F[A]]): Codec[F[A]] = {
     guard(codec){ fa =>
       if (fa.size >= sz) None
       else Some(Err(s"Expected at least $sz items, got ${fa.size}"))
@@ -661,7 +659,7 @@ object codec {
   }
 
   /** will encode a collection of `A` with at max size of `sz` **/
-  def maxItems[A, F[_] <: GenTraversable[_]](sz:Int)(codec: Codec[F[A]]): Codec[F[A]] = {
+  def maxItems[A, F[_] <: Iterable[_]](sz:Int)(codec: Codec[F[A]]): Codec[F[A]] = {
     guard(codec){ fa =>
       if (fa.size <= sz) None
       else Some(Err(s"Expected at max $sz items, got ${fa.size}"))

--- a/common/src/test/scala/spinoco/protocol/common/ProtocolSpec.scala
+++ b/common/src/test/scala/spinoco/protocol/common/ProtocolSpec.scala
@@ -1,15 +1,14 @@
 package spinoco.protocol.common
 
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.Matchers
+import org.scalatest.{FreeSpec, Matchers}
 import org.scalatest.concurrent.{Eventually, TimeLimitedTests}
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.time.SpanSugar._
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 /**
   * Created by pach on 23/07/16.
   */
-class ProtocolSpec extends AnyFreeSpec
+class ProtocolSpec extends FreeSpec
   with ScalaCheckDrivenPropertyChecks
   with Matchers
   with TimeLimitedTests

--- a/common/src/test/scala/spinoco/protocol/common/ProtocolSpec.scala
+++ b/common/src/test/scala/spinoco/protocol/common/ProtocolSpec.scala
@@ -1,15 +1,16 @@
 package spinoco.protocol.common
 
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.Matchers
 import org.scalatest.concurrent.{Eventually, TimeLimitedTests}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.time.SpanSugar._
 
 /**
   * Created by pach on 23/07/16.
   */
-class ProtocolSpec extends FreeSpec
-  with GeneratorDrivenPropertyChecks
+class ProtocolSpec extends AnyFreeSpec
+  with ScalaCheckDrivenPropertyChecks
   with Matchers
   with TimeLimitedTests
   with Eventually {

--- a/http/src/main/scala/spinoco/protocol/http/Uri.scala
+++ b/http/src/main/scala/spinoco/protocol/http/Uri.scala
@@ -146,7 +146,7 @@ object Uri {
       }
       Path(
         initialSlash =  trimmed.startsWith("/")
-        , segments = segments
+        , segments = segments.toIndexedSeq
         , trailingSlash = trimmed.endsWith("/") && segments.nonEmpty
       )
     }

--- a/http/src/test/scala/spinoco/protocol/http/codec/HeaderCodecSpec.scala
+++ b/http/src/test/scala/spinoco/protocol/http/codec/HeaderCodecSpec.scala
@@ -15,6 +15,7 @@ import spinoco.protocol.mime.ContentType._
 import spinoco.protocol.mime.MediaType.CustomMediaType
 import spinoco.protocol.mime._
 
+import scala.collection.immutable.ListMap
 import scala.concurrent.duration._
 
 
@@ -195,7 +196,7 @@ property("Accept-Ranges Header") = secure {
         , Authorization(HttpCredentials.OAuthToken("Bearer", "mF_9.B5f-4.1JqM"))
         , "Authorization: Bearer mF_9.B5f-4.1JqM")
       , ("Authorization: Digest username=\"Mufasa\",\n                 realm=\"testrealm@host.com\",\n                 nonce=\"dcd98b7102dd2f0e8b11d0f600bfb0c093\",\n                 uri=\"/dir/index.html\",\n                 qop=auth,\n                 nc=00000001,\n         cnonce=\"0a4f113b\",\n                 response=\"6629fae49393a05397450978507c4ef1\",\n                 opaque=\"5ccc069c403ebaf9f0171e9517f40e41\""
-        , Authorization(HttpCredentials.DigestHttpCredentials("Digest", Map(
+        , Authorization(HttpCredentials.DigestHttpCredentials("Digest", ListMap(
         "username" -> "Mufasa"
         , "realm" -> "testrealm@host.com"
         , "nonce" -> "dcd98b7102dd2f0e8b11d0f600bfb0c093"
@@ -206,7 +207,7 @@ property("Accept-Ranges Header") = secure {
         , "response" -> "6629fae49393a05397450978507c4ef1"
         , "opaque" -> "5ccc069c403ebaf9f0171e9517f40e41"
       )))
-        , "Authorization: Digest nc=00000001, nonce=dcd98b7102dd2f0e8b11d0f600bfb0c093, username=Mufasa, uri=\"/dir/index.html\", cnonce=0a4f113b, qop=auth, response=6629fae49393a05397450978507c4ef1, opaque=5ccc069c403ebaf9f0171e9517f40e41, realm=\"testrealm@host.com\"")
+        , "Authorization: Digest username=Mufasa, realm=\"testrealm@host.com\", nonce=dcd98b7102dd2f0e8b11d0f600bfb0c093, uri=\"/dir/index.html\", qop=auth, nc=00000001, cnonce=0a4f113b, response=6629fae49393a05397450978507c4ef1, opaque=5ccc069c403ebaf9f0171e9517f40e41")
     ))
   }
 

--- a/kafka/src/main/scala/spinoco/protocol/kafka/codec/MessageCodec.scala
+++ b/kafka/src/main/scala/spinoco/protocol/kafka/codec/MessageCodec.scala
@@ -4,9 +4,11 @@ import scodec.bits.BitVector
 import scodec.{Attempt, Codec}
 import scodec.codecs._
 import shapeless.{::, HNil}
+import shapeless.Typeable.simpleTypeable
 import spinoco.protocol.kafka._
 import spinoco.protocol.common.util._
 import spinoco.protocol.kafka.Request.{FetchRequest, MetadataRequest, OffsetsRequest, ProduceRequest}
+import spinoco.protocol.kafka.Response.{FetchResponse, MetadataResponse, OffsetResponse, ProduceResponse}
 
 
 object MessageCodec {
@@ -26,13 +28,12 @@ object MessageCodec {
   /** decodes concrete response **/
   def responseCodecFor(version: ProtocolVersion.Value, apiKey:ApiKey.Value):Codec[Response] = {
     apiKey match {
-      case ApiKey.FetchRequest => FetchCodec.responseCodec(version).upcast
-      case ApiKey.MetadataRequest => MetadataCodec.metadataResponseCodec.upcast
-      case ApiKey.ProduceRequest => ProduceCodec.produceResponseCodec(version).upcast
-      case ApiKey.OffsetRequest => OffsetCodec.responseCodec(version).upcast
+      case ApiKey.FetchRequest => FetchCodec.responseCodec(version).upcast(simpleTypeable(classOf[FetchResponse]))
+      case ApiKey.MetadataRequest => MetadataCodec.metadataResponseCodec.upcast(simpleTypeable(classOf[MetadataResponse]))
+      case ApiKey.ProduceRequest => ProduceCodec.produceResponseCodec(version).upcast(simpleTypeable(classOf[ProduceResponse]))
+      case ApiKey.OffsetRequest => OffsetCodec.responseCodec(version).upcast(simpleTypeable(classOf[OffsetResponse]))
     }
   }
-
 
   object impl {
 
@@ -103,12 +104,12 @@ object MessageCodec {
       requestHeaderCodec.flatZip[Request] {
         case api :: version :: _ =>
           api match {
-            case ApiKey.ProduceRequest => ProduceCodec.requestCodec.upcast
-            case ApiKey.FetchRequest => FetchCodec.requestCodec(version).upcast
-            case ApiKey.MetadataRequest => MetadataCodec.requestCodec.upcast
-            case ApiKey.OffsetRequest => OffsetCodec.requestCodec(version).upcast
+            case ApiKey.ProduceRequest => ProduceCodec.requestCodec.upcast(simpleTypeable(classOf[ProduceRequest]))
+            case ApiKey.FetchRequest => FetchCodec.requestCodec(version).upcast(simpleTypeable(classOf[FetchRequest]))
+            case ApiKey.MetadataRequest => MetadataCodec.requestCodec.upcast(simpleTypeable(classOf[MetadataRequest]))
+            case ApiKey.OffsetRequest => OffsetCodec.requestCodec(version).upcast(simpleTypeable(classOf[OffsetsRequest]))
           }
-      }.xmap(decode _ tupled,encode)
+      }.xmap(decode _ tupled, encode)
     }
 
   }

--- a/ldap/src/main/scala/spinoco/protocol/ldap/package.scala
+++ b/ldap/src/main/scala/spinoco/protocol/ldap/package.scala
@@ -42,7 +42,7 @@ package object ldap {
           if (bits == trueVector) Right(true)
           else Right(false)
         }
-        .right.map{ case (remaining, value) => DecodeResult(value, remaining)}
+        .map{ case (remaining, value) => DecodeResult(value, remaining)}
         .left.map(err => Err("Could not decode LDAP boolean due to: " + err))
       )
     }

--- a/ldap/src/test/scala/spinoco/protocol/ldap/LDAPMessageSpec.scala
+++ b/ldap/src/test/scala/spinoco/protocol/ldap/LDAPMessageSpec.scala
@@ -1,4 +1,5 @@
-package spinoco.protocol.ldap
+package spinoco.protocol
+package ldap
 
 import org.scalacheck.Prop._
 import org.scalacheck.{Prop, Properties}
@@ -29,7 +30,7 @@ object LDAPMessageSpec extends Properties("LDAPMessage"){
       , BindRequest(
         3
         , LdapDN.decode("dc=admin").require
-        , BindRequest.Simple(ByteVector.encodeUtf8("admin").right.get)
+        , BindRequest.Simple(ByteVector.encodeUtf8("admin").toOption.get)
       )
       , None
     ), BitVector.fromValidHex("30190201016014020103040864633d61646d696e800561646d696e"))(LdapMessage.codec)
@@ -65,7 +66,7 @@ object LDAPMessageSpec extends Properties("LDAPMessage"){
         , sizeLimit = 50
         , timeLimit = 0
         , typesOnly = false
-        , filter = Filter.And(Set(Filter.Present(AttributeDescription.Recognised(AttributeDescription.AttributeType.commonName)), Filter.SubstringFilter(AttributeDescription.TextDescriptor("sn"), SubStrings(Some(SubStrings.Initial(ByteVector.encodeUtf8("J").right.get)), Vector.empty, None))))
+        , filter = Filter.And(Set(Filter.Present(AttributeDescription.Recognised(AttributeDescription.AttributeType.commonName)), Filter.SubstringFilter(AttributeDescription.TextDescriptor("sn"), SubStrings(Some(SubStrings.Initial(ByteVector.encodeUtf8("J").toOption.get)), Vector.empty, None))))
         , attributes = Vector(
           AttributeSelector.Description(AttributeDescription.Recognised(AttributeDescription.AttributeType.commonName))
           , AttributeSelector.Description(AttributeDescription.TextDescriptor("sn"))

--- a/mail/src/main/scala/spinoco/protocol/mail/header/`Auto-Submitted`.scala
+++ b/mail/src/main/scala/spinoco/protocol/mail/header/`Auto-Submitted`.scala
@@ -25,7 +25,7 @@ object `Auto-Submitted` extends DefaultHeaderDescription[`Auto-Submitted`] {
     Attempt.fromEither(
       Try(AutoType.withName(a)).toOption
       .toRight(Err("Could not parse Auto-Submitted header due to invalid tpe: " + a))
-      .right.map(`Auto-Submitted`(_))
+      .map(`Auto-Submitted`(_))
     )
   }
   , b => {

--- a/mail/src/main/scala/spinoco/protocol/mail/header/`Return-Path`.scala
+++ b/mail/src/main/scala/spinoco/protocol/mail/header/`Return-Path`.scala
@@ -23,7 +23,7 @@ object `Return-Path` extends DefaultHeaderDescription[`Return-Path`] {
           `Return-Path`(s0.trim)
         }
       }
-      , rp => '<' + rp.path + '>'
+      , rp => s"<${rp.path}>"
     )
   }
 

--- a/mail/src/main/scala/spinoco/protocol/mail/header/codec/EmailAddressCodec.scala
+++ b/mail/src/main/scala/spinoco/protocol/mail/header/codec/EmailAddressCodec.scala
@@ -3,7 +3,7 @@ package spinoco.protocol.mail.header.codec
 import scodec.bits.BitVector
 import scodec.codecs._
 import scodec.{Attempt, Codec, Err}
-import spinoco.protocol.common.codec._
+import spinoco.protocol.common.codec.{quotedString => _, _}
 import spinoco.protocol.mail.EmailAddress
 
 /**

--- a/mail/src/main/scala/spinoco/protocol/mail/imap/codec/IMAPBodyPartCodec.scala
+++ b/mail/src/main/scala/spinoco/protocol/mail/imap/codec/IMAPBodyPartCodec.scala
@@ -7,6 +7,7 @@ import scodec._
 import scodec.bits.BitVector
 import scodec.codecs._
 import shapeless.{::, HNil}
+import shapeless.Typeable.simpleTypeable
 import spinoco.protocol.common.codec._
 import spinoco.protocol.mail.EmailAddress
 import spinoco.protocol.mail.header.codec.{DateTimeCodec, RFC2047Codec}
@@ -22,8 +23,8 @@ object IMAPBodyPartCodec {
   lazy val codec: Codec[BodyPart] = {
     `(` ~>
       choice(
-        ("multi body"         | multiBodyPart.upcast[BodyPart])
-        , ("single body"      | singleBodyPart.upcast[BodyPart])
+        ("multi body"         | multiBodyPart.upcast[BodyPart](simpleTypeable(classOf[MultiBodyPart])))
+        , ("single body"      | singleBodyPart.upcast[BodyPart](simpleTypeable(classOf[SingleBodyPart])))
       ) <~
      `)`
   }

--- a/mail/src/test/scala/spinoco/protocol/mail/EmailHeaderSpec.scala
+++ b/mail/src/test/scala/spinoco/protocol/mail/EmailHeaderSpec.scala
@@ -80,7 +80,7 @@ object EmailHeaderSpec extends  Properties("EmailHeader") {
         |Content-Transfer-Encoding: base64
         |Auto-Submitted: auto-notified
         |
-        |""".stripMargin.lines.mkString("\r\n")
+        |""".stripMargin.linesWithSeparators.map(_.stripLineEnd).mkString("\r\n")
 
 
     EmailHeaderCodec.codec(Int.MaxValue).decodeValue(ByteVector.view(email.getBytes).bits).map { header =>
@@ -151,7 +151,7 @@ object EmailHeaderSpec extends  Properties("EmailHeader") {
                    |Content-Type: text/html; charset=utf-8
                    |Content-Transfer-Encoding: base64
                    |
-                   |""".stripMargin.lines.mkString("\r\n").getBytes)
+                   |""".stripMargin.linesWithSeparators.map(_.stripLineEnd).mkString("\r\n").getBytes)
 
 
     encoded ?= Attempt.successful(expect.bits)

--- a/mgcp/src/main/scala/spinoco/protocol/mgcp/codec/MGCPParameterCodec.scala
+++ b/mgcp/src/main/scala/spinoco/protocol/mgcp/codec/MGCPParameterCodec.scala
@@ -133,7 +133,7 @@ object MGCPParameterCodec {
       (intAsString :: optional(recover2(constant(BitVector.view("-".getBytes))), intAsString)).as[Bandwidth]
 
     val echoCancelCodec: Codec[EchoCancel] =
-      mappedEnum(ascii, Map(true -> "on", false -> "off" ))
+      (mappedEnum(ascii, Map(true -> "on", false -> "off" )): Codec[Boolean])
         .as[EchoCancel]
 
     val packetizationPeriodCodec: Codec[PacketizationPeriod] =
@@ -146,7 +146,7 @@ object MGCPParameterCodec {
       ).as[GainControl]
 
     val silenceSuppressionCodec: Codec[SilenceSuppression] =
-      mappedEnum(ascii, Map(true -> "on", false -> "off" ))
+      (mappedEnum(ascii, Map(true -> "on", false -> "off" )): Codec[Boolean])
         .as[SilenceSuppression]
 
 
@@ -314,7 +314,7 @@ object MGCPParameterCodec {
 
 
   val reasonCodeCodec: Codec[ReasonCode] = {
-    stringEnumerated(ascii, ReasonCodeType).as[ReasonCode]
+    (stringEnumerated(ascii, ReasonCodeType): Codec[ReasonCodeType.Value]).as[ReasonCode]
   }
 
   val specificEndpointIDCodec: Codec[SpecificEndpointID] =
@@ -341,7 +341,7 @@ object MGCPParameterCodec {
     listOfParametrizedEvents.as[DetectEvents]
 
   val restartMethodCodec: Codec[RestartMethod] =
-    stringEnumerated(ascii, RestartMethodType).as[RestartMethod]
+    (stringEnumerated(ascii, RestartMethodType): Codec[RestartMethodType.Value]).as[RestartMethod]
 
   val restartDelayCodec: Codec[RestartDelay] =
     intAsString.xmap[FiniteDuration](_.seconds, _.toSeconds.toInt).as[RestartDelay]

--- a/mgcp/src/test/scala/spinoco/protocol/mgcp/codec/MGCPCommandCodecSpec.scala
+++ b/mgcp/src/test/scala/spinoco/protocol/mgcp/codec/MGCPCommandCodecSpec.scala
@@ -16,7 +16,7 @@ import spinoco.protocol.sdp._
 object MGCPCommandCodecSpec extends Properties("MGCPCommandCodec"){
 
   def encode(command: MGCPCommand)(encoded: String): Prop = {
-    "Encode" |: (MGCPCommandCodec.codec.encode(command).map(_.decodeUtf8) ?= Attempt.successful(Right(encoded.lines.mkString("", "\r\n", "\r\n"))))
+    "Encode" |: (MGCPCommandCodec.codec.encode(command).map(_.decodeUtf8) ?= Attempt.successful(Right(encoded.linesWithSeparators.map(_.stripLineEnd).mkString("", "\r\n", "\r\n"))))
   }
 
   def decode(command: MGCPCommand)(encoded: String): Prop = {

--- a/mime/src/main/scala/spinoco/protocol/mime/ContentType.scala
+++ b/mime/src/main/scala/spinoco/protocol/mime/ContentType.scala
@@ -59,7 +59,7 @@ object ContentType {
         , { case Parameters(charset, params) =>
 
           if (required.forall(params.isDefinedAt)) {
-            Attempt.successful(params.mapValues(Right(_)).toList ++ charset.map("charset" -> Left(_)).toList)
+            Attempt.successful(params.map { case (k, v) => k -> Right(v) }.toList ++ charset.map("charset" -> Left(_)).toList)
           } else {
             Attempt.failure(Err(s"Invalid media type. Parameters ${required.mkString(", ")} are required for $mediaType"))
           }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.9.5")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.3.5")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.9.5")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")

--- a/rtp/src/main/scala/spinoco/protocol/rtp/codec/codec.scala
+++ b/rtp/src/main/scala/spinoco/protocol/rtp/codec/codec.scala
@@ -27,6 +27,6 @@ package object codec {
     , 0 -> ByteVector.empty
   )
 
-  val paddingMapBits = paddingMapBytes.mapValues(_.bits)
+  val paddingMapBits = paddingMapBytes.map { case (k, v) => k -> v.bits }
 
 }


### PR DESCRIPTION
Unfortunately, I didn't  notice that kafka isn't yet published for 2.13 and according to their JIRA it scheduled for 2.4.0, so we should not expect to get it pretty soon. 

I'll try to setup some cross-build stuff in a couple of days.